### PR TITLE
fix Fate capitalization

### DIFF
--- a/_posts/2021-04-11-fate.md
+++ b/_posts/2021-04-11-fate.md
@@ -1,19 +1,19 @@
 ---
 layout: single
-title:  "FATE Core"
+title:  "Fate Core"
 permalink: fate-core
 tags:
 - Evil Hat
 - theatre of the mind
 - d6
 - FUDGE
-- FATE
+- Fate
 category: 
 - Fantasy
 - Modern Day
 - Sci-Fi
 sidebar:
-- title: "FATE Core"
+- title: "Fate Core"
   image: http://www.evilhat.com/home/wp-content/uploads/2013/04/FateCoreBookCover.jpg
 - title: "Publisher"
   text: "[Evil Hat Productions](https://www.evilhat.com/)"
@@ -29,36 +29,36 @@ header:
 
 # What's the concept?
 
-FATE is a game about proactive, capable characters that lead dramatic lives. The system encourages using the rules to add new skills, stunts and abilities to make the game work in any genre you want to play.
+Fate is a game about proactive, capable characters that lead dramatic lives. The system encourages using the rules to add new skills, stunts and abilities to make the game work in any genre you want to play.
 
 # How does it work?
 
 Characters are created collaboratively so that all the characters have ties to at least two other characters' backstory. This make sit very easy to setup a one shot game where the characters feel linked. Every character will have descriptive aspects of their character that can be invoked to increase the drama of the game.
 
-Every character has a skill pyramid that showcases what the player is good at and what they are less good at with skills ranked from _Terrible_ to _Legendary_ giving bonuses to your FATE dice rolls. Characters take dramatic actions whether that be combat, flying a zeppelin or playing an excellent hand of cards. 
+Every character has a skill pyramid that showcases what the player is good at and what they are less good at with skills ranked from _Terrible_ to _Legendary_ giving bonuses to your Fate dice rolls. Characters take dramatic actions whether that be combat, flying a zeppelin or playing an excellent hand of cards. 
 
-The GM (gamemaster) creates the world and characters that the players will face off against and sets up the overarching story. The GM can give players a FATE point to make them act out their aspects and players can spend FATE points to change the results of dice by invoking aspects in play leading to a very collaborative story told by players and GM alike.
+The GM (gamemaster) creates the world and characters that the players will face off against and sets up the overarching story. The GM can give players a Fate point to make them act out their aspects and players can spend Fate points to change the results of dice by invoking aspects in play leading to a very collaborative story told by players and GM alike.
 
 # What do I need to get started?
 
 ## The Rules
 
-The FATE Core rulebook is all you need. It covers all the rules to play a game of FATE. There are additional books which expand on FATE Core from worldbuilding to toolkits for specific types of games but they are not required to play.
+The Fate Core rulebook is all you need. It covers all the rules to play a game of Fate. There are additional books which expand on Fate Core from worldbuilding to toolkits for specific types of games but they are not required to play.
 
-_[FATE Core](http://www.evilhat.com/home/wp-content/uploads/FateCore.zip) is available to download for free._
+_[Fate Core](http://www.evilhat.com/home/wp-content/uploads/FateCore.zip) is available to download for free._
 
 ## The Dice
 
-A set of FATE dice is essentially just 4d6 (for each player). You can buy special FATE dice that have 2 plus, 2 minus and 2 blank sides. You can simulate this with standard six sided dice by treating 5s and 6s as pluses and 1s and 2s as minuses.
+A set of Fate dice is essentially just 4d6 (for each player). You can buy special Fate dice that have 2 plus, 2 minus and 2 blank sides. You can simulate this with standard six sided dice by treating 5s and 6s as pluses and 1s and 2s as minuses.
 
 ## How much will that cost?
 
-The FATE Core Rulebook costs $25 and comes with a free pdf. You can [download FATE Core](http://www.evilhat.com/home/wp-content/uploads/FateCore.zip) for free directly from the publisher.
+The Fate Core Rulebook costs $25 and comes with a free pdf. You can [download Fate Core](http://www.evilhat.com/home/wp-content/uploads/FateCore.zip) for free directly from the publisher.
 
-Official FATE dice cost about $15.
+Official Fate dice cost about $15.
 
 # Where do I learn more?
 
-* [Evil Hat's FATE Page](https://www.evilhat.com/home/fate-core/)
-* [FATE SRD](https://fate-srd.com/)
-* [FATE Dice Roler](https://matita.github.io/fatedice/)
+* [Evil Hat's Fate Page](https://www.evilhat.com/home/fate-core/)
+* [Fate SRD](https://fate-srd.com/)
+* [Fate Dice Roller](https://matita.github.io/fatedice/)


### PR DESCRIPTION
Fate's name shouldn't be in all caps; it used to be considered an acronym, but is no longer one.